### PR TITLE
Add labels arguments dictionary, e.g. to set fontsize, etc.

### DIFF
--- a/triangle.py
+++ b/triangle.py
@@ -28,7 +28,7 @@ import matplotlib.cm as cm
 
 
 def corner(xs, weights=None, labels=None, show_titles=False, title_fmt=".2f",
-           title_args={}, extents=None, truths=None, truth_color="#4682b4",
+           title_args={}, labels_args={}, extents=None, truths=None, truth_color="#4682b4",
            scale_hist=False, quantiles=[], verbose=True,
            plot_contours=True, plot_datapoints=True, fig=None, **kwargs):
     """
@@ -215,7 +215,7 @@ def corner(xs, weights=None, labels=None, show_titles=False, title_fmt=".2f",
         else:
             [l.set_rotation(45) for l in ax.get_xticklabels()]
             if labels is not None:
-                ax.set_xlabel(labels[i])
+                ax.set_xlabel(labels[i],**labels_args)
                 ax.xaxis.set_label_coords(0.5, -0.3)
 
         for j, y in enumerate(xs):
@@ -248,7 +248,7 @@ def corner(xs, weights=None, labels=None, show_titles=False, title_fmt=".2f",
             else:
                 [l.set_rotation(45) for l in ax.get_xticklabels()]
                 if labels is not None:
-                    ax.set_xlabel(labels[j])
+                    ax.set_xlabel(labels[j],**labels_args)
                     ax.xaxis.set_label_coords(0.5, -0.3)
 
             if j > 0:
@@ -256,7 +256,7 @@ def corner(xs, weights=None, labels=None, show_titles=False, title_fmt=".2f",
             else:
                 [l.set_rotation(45) for l in ax.get_yticklabels()]
                 if labels is not None:
-                    ax.set_ylabel(labels[i])
+                    ax.set_ylabel(labels[i],**labels_args)
                     ax.yaxis.set_label_coords(-0.3, 0.5)
 
     return fig


### PR DESCRIPTION
I added a dictionary for the labels arguments, in the same style of title arguments.
In this way it is possible to customize the labels, e.g. the fontsize, etc.
I am using this feature for my plots (attach one of them).

![triangle_chain_1900](https://cloud.githubusercontent.com/assets/6020226/2861571/223944e0-d1e1-11e3-86f2-72831b30d643.png)


