### PR TITLE
Filled contour changes and use of scientific notation for tick labels

### DIFF
--- a/triangle.py
+++ b/triangle.py
@@ -112,6 +112,9 @@ def corner(xs, bins=20, range=None, weights=None, color="k",
         Add no filling at all to the contours (unlike setting ``fill_contours=False``,
         which still adds a white fill at the densest points)
 
+    bins2d : int (optional)
+        Set the number of bins in the 2D histogram for density/contour plots (default: 20)
+
     plot_datapoints : bool (optional)
         Draw the individual data points.
 
@@ -317,7 +320,12 @@ def corner(xs, bins=20, range=None, weights=None, color="k",
             # Deal with masked arrays.
             if hasattr(y, "compressed"):
                 y = y.compressed()
-            hist2d(y, x, ax=ax, range=[range[j], range[i]], weights=weights,
+                
+            # set histogram bins for contour/density plots
+            bins2d = 20
+            if "bins2d" in hist2d_kwargs:
+                bins2d = hist2d_kwargs["bins2d"]
+            hist2d(y, x, bins=bins2d, ax=ax, range=[range[j], range[i]], weights=weights,
                    color=color, smooth=smooth, **hist2d_kwargs)
 
             if truths is not None:

--- a/triangle.py
+++ b/triangle.py
@@ -29,6 +29,7 @@ import numpy as np
 import matplotlib.pyplot as pl
 from matplotlib.ticker import MaxNLocator
 from matplotlib.colors import LinearSegmentedColormap, colorConverter
+from matplotlib.ticker import ScalarFormatter
 
 try:
     from scipy.ndimage import gaussian_filter
@@ -42,7 +43,8 @@ def corner(xs, bins=20, range=None, weights=None, color="k",
            show_titles=False, title_fmt=".2f", title_kwargs=None,
            truths=None, truth_color="#4682b4",
            scale_hist=False, quantiles=None, verbose=False, fig=None,
-           max_n_ticks=5, top_ticks=False, hist_kwargs=None, **hist2d_kwargs):
+           max_n_ticks=5, top_ticks=False, use_math_text=False,
+           hist_kwargs=None, **hist2d_kwargs):
     """
     Make a *sick* corner plot showing the projections of a data set in a
     multi-dimensional space. kwargs are passed to hist2d() or used for
@@ -75,7 +77,7 @@ def corner(xs, bins=20, range=None, weights=None, color="k",
     title_args : dict (optional)
         Any extra keyword arguments to send to the `add_title` command.
 
-    extents : iterable (ndim,) (optional)
+    range : iterable (ndim,) (optional)
         A list where each element is either a length 2 tuple containing
         lower and upper bounds (extents) or a float in range (0., 1.)
         giving the fraction of samples to include in bounds, e.g.,
@@ -101,6 +103,10 @@ def corner(xs, bins=20, range=None, weights=None, color="k",
 
     plot_contours : bool (optional)
         Draw contours for dense regions of the plot.
+
+    use_math_text : bool (optional)
+        If true then axis tick labels for very large or small exponents will be
+        displayed as powers of 10 rather than using `e`
 
     no_fill_contours : bool (optional)
         Add no filling at all to the contours (unlike setting ``fill_contours=False``,
@@ -293,6 +299,9 @@ def corner(xs, bins=20, range=None, weights=None, color="k",
                 ax.set_xlabel(labels[i], **label_kwargs)
                 ax.xaxis.set_label_coords(0.5, -0.3)
 
+            # use MathText for axes ticks
+            ax.xaxis.set_major_formatter(ScalarFormatter(useMathText=use_math_text))
+
         for j, y in enumerate(xs):
             if np.shape(xs)[0] == 1:
                 ax = axes
@@ -327,6 +336,9 @@ def corner(xs, bins=20, range=None, weights=None, color="k",
                     ax.set_xlabel(labels[j], **label_kwargs)
                     ax.xaxis.set_label_coords(0.5, -0.3)
 
+                # use MathText for axes ticks
+                ax.xaxis.set_major_formatter(ScalarFormatter(useMathText=use_math_text))
+
             if j > 0:
                 ax.set_yticklabels([])
             else:
@@ -334,6 +346,9 @@ def corner(xs, bins=20, range=None, weights=None, color="k",
                 if labels is not None:
                     ax.set_ylabel(labels[i], **label_kwargs)
                     ax.yaxis.set_label_coords(-0.3, 0.5)
+
+                # use MathText for axes ticks
+                ax.yaxis.set_major_formatter(ScalarFormatter(useMathText=use_math_text))
 
     return fig
 

--- a/triangle.py
+++ b/triangle.py
@@ -102,6 +102,10 @@ def corner(xs, bins=20, range=None, weights=None, color="k",
     plot_contours : bool (optional)
         Draw contours for dense regions of the plot.
 
+    no_fill_contours : bool (optional)
+        Add no filling at all to the contours (unlike setting ``fill_contours=False``,
+        which still adds a white fill at the densest points)
+
     plot_datapoints : bool (optional)
         Draw the individual data points.
 
@@ -355,7 +359,7 @@ def quantile(x, q, weights=None):
 
 def hist2d(x, y, bins=20, range=None, weights=None, levels=None, smooth=None,
            ax=None, color=None, plot_datapoints=True, plot_density=True,
-           plot_contours=True, fill_contours=False,
+           plot_contours=True, no_fill_contours=False, fill_contours=False,
            contour_kwargs=None, contourf_kwargs=None, data_kwargs=None,
            **kwargs):
     """
@@ -460,7 +464,7 @@ def hist2d(x, y, bins=20, range=None, weights=None, levels=None, smooth=None,
         ax.plot(x, y, "o", zorder=-1, rasterized=True, **data_kwargs)
 
     # Plot the base fill to hide the densest data points.
-    if plot_contours or plot_density:
+    if (plot_contours or plot_density) and not no_fill_contours:
         ax.contourf(X2, Y2, H2.T, [V[-1], H.max()],
                     cmap=white_cmap, antialiased=False)
 


### PR DESCRIPTION
I've made three changes that might be useful to others.
 1. currently with `fill_contours=False` the contours are still filled in in the highest density region. On occasion I've wanted absolutely no filling in the contours, so I've created a new input argument (`no_fill_contours`), which if true means that just the contour outlines are plotted. The argument name may want changing to something different though!
 2. For very large or small numbers the tick labels are currently in the `e` format (e.g 2.0e-20), so I've created the option of using [MathText](http://matplotlib.org/api/ticker_api.html#matplotlib.ticker.ScalarFormatter) to output them in scientific notation (e.g. 2.0&times;10<sup>-20</sup>) if required.
 3. ~~Currently the number of histogram bins for the 2d histogram is set to 20 and can't be changed as the ``bins`` arguments for the ``corner`` functions means that another ``bins`` argument can't be added as a ``hist2d_kwargs`` argument. So, I've set it that if ``bins2d`` is set as a ``hist2d_kwargs`` argument then this value will be used for the 2d histogram binning (it will default back to 20 bins).~~ (I've removed this as it was not required following merging of Will's pull request #46)