### PR TITLE
Allow the user to call tight_layout

### DIFF
--- a/triangle.py
+++ b/triangle.py
@@ -192,14 +192,13 @@ def corner(xs, bins=20, range=None, weights=None, color="k",
 
     # Create a new figure if one wasn't provided.
     if fig is None:
-        fig, axes = pl.subplots(K, K, figsize=(dim, dim), tight_layout=False)
+        fig, axes = pl.subplots(K, K, figsize=(dim, dim))
     else:
         try:
             axes = np.array(fig.axes).reshape((K, K))
         except:
             raise ValueError("Provided figure has {0} axes, but data has "
                              "dimensions K={1}".format(len(fig.axes), K))
-        fig.set_tight_layout(False)
 
     # Format the figure.
     lb = lbdim / dim
@@ -296,8 +295,9 @@ def corner(xs, bins=20, range=None, weights=None, color="k",
             else:
                 ax = axes[i, j]
             if j > i:
-                ax.set_visible(False)
                 ax.set_frame_on(False)
+                ax.set_xticks([])
+                ax.set_yticks([])
                 continue
             elif j == i:
                 continue


### PR DESCRIPTION
The use of `set_visible(False)` breaks the `tight_layout()` routine and
produces a AttributeError when it is called.  This replaces the
`set_visible` call by removing the ticks manually and, since there is
now no need to force the `tight_layout` to be False, also removes the
occurances of this.